### PR TITLE
Feature/inline html action

### DIFF
--- a/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionRequest.java
+++ b/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionRequest.java
@@ -56,7 +56,7 @@ public class ActionRequest {
   }
 
   public JsonObject getMetadata() {
-    return metadata;
+    return metadata.copy();
   }
 
   public JsonObject toJson() {

--- a/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionResponse.java
+++ b/api/src/main/java/io/knotx/fragments/handler/api/domain/payload/ActionResponse.java
@@ -73,7 +73,7 @@ public class ActionResponse {
   }
 
   public JsonObject getMetadata() {
-    return metadata;
+    return metadata.copy();
   }
 
   public JsonObject toJson() {

--- a/core/README.md
+++ b/core/README.md
@@ -57,12 +57,30 @@ actions {
   }
   
   product-fallback {
-    factory = "static"
+    factory = "inline-body"
     config {
-      markup = <div>Product not available at the moment</div>
+      body = <div>Product not available at the moment</div>
     }
   }
 }
 ```
 
 Read more about configuring fragment graph in the [Data Object docs](https://github.com/Knotx/knotx-fragments-handler/blob/master/core/docs/asciidoc/dataobjects.adoc).
+
+
+## Actions
+
+### Inline Body Action
+Inline Body Action replaces Fragment body with specified value. Its configuration looks like:
+```hocon
+product-fallback {
+    factory = "inline-body"
+    config {
+      body = <div>Product not available at the moment</div>
+    }
+}
+```
+
+The default `body` value is empty content.
+
+## Behaviours 

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.action;
 
 import io.knotx.fragments.handler.api.Action;

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
@@ -13,12 +13,12 @@ import io.vertx.core.json.JsonObject;
  *   inlineBodyFallback {
  *     name = inline-body,
  *     config {
- *       body = "<div>some static content</div>"
+ *       body = "some static content"
  *     }
  *   }
  * </pre>
- * WARNING: This action modifies Fragment body so it should not be used in composite nodes {@see
- * io.knotx.fragments.handler.options.NodeOptions#isComposite()}.
+ * WARNING: This action modifies Fragment body so it should not be used in composite nodes
+ * {@link io.knotx.fragments.handler.options.NodeOptions#isComposite()}.
  */
 public class InlineBodyActionFactory implements ActionFactory {
 

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
@@ -2,6 +2,7 @@ package io.knotx.fragments.handler.action;
 
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
+import io.knotx.fragments.handler.api.Cacheable;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -20,6 +21,7 @@ import io.vertx.core.json.JsonObject;
  * WARNING: This action modifies Fragment body so it should not be used in composite nodes
  * {@link io.knotx.fragments.handler.options.NodeOptions#isComposite()}.
  */
+@Cacheable
 public class InlineBodyActionFactory implements ActionFactory {
 
   private static final String DEFAULT_EMPTY_BODY = "";

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlineBodyActionFactory.java
@@ -1,0 +1,54 @@
+package io.knotx.fragments.handler.action;
+
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.ActionFactory;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Inline body action factory class. It can be initialized with a configuration:
+ * <pre>
+ *   inlineBodyFallback {
+ *     name = inline-body,
+ *     config {
+ *       body = "<div>some static content</div>"
+ *     }
+ *   }
+ * </pre>
+ * WARNING: This action modifies Fragment body so it should not be used in composite nodes {@see
+ * io.knotx.fragments.handler.options.NodeOptions#isComposite()}.
+ */
+public class InlineBodyActionFactory implements ActionFactory {
+
+  private static final String DEFAULT_EMPTY_BODY = "";
+
+  @Override
+  public String getName() {
+    return "inline-body";
+  }
+
+  /**
+   * Creates inline body action that replaces Fragment body with static content.
+   *
+   * @param alias - action alias
+   * @param config - JSON configuration
+   * @param vertx - vertx instance
+   * @param doAction - <pre>null</pre> value expected
+   */
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    if (doAction != null) {
+      throw new IllegalArgumentException("Inline body action does not support doAction");
+    }
+    return (fragmentContext, resultHandler) -> {
+      fragmentContext.getFragment()
+          .setBody(config.getString("body", DEFAULT_EMPTY_BODY));
+      Future<FragmentResult> resultFuture = Future.succeededFuture(
+          new FragmentResult(fragmentContext.getFragment(), FragmentResult.SUCCESS_TRANSITION));
+      resultFuture.setHandler(resultHandler);
+    };
+  }
+
+}

--- a/core/src/main/resources/META-INF/services/io.knotx.fragments.handler.api.ActionFactory
+++ b/core/src/main/resources/META-INF/services/io.knotx.fragments.handler.api.ActionFactory
@@ -12,5 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-io.knotx.fragments.handler.action.KnotFactory
+# behaviours
 io.knotx.fragments.handler.action.CircuitBreakerActionFactory
+
+# pre-defined actions
+io.knotx.fragments.handler.action.InlineBodyActionFactory
+io.knotx.fragments.handler.action.KnotFactory

--- a/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
+++ b/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
@@ -1,0 +1,71 @@
+package io.knotx.fragments.handler.action;
+
+import io.knotx.fragment.Fragment;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.server.api.context.ClientRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class InlineBodyActionFactoryTest {
+
+  private static final String EXPECTED_VALUE = "expected value";
+  private static final String INITIAL_BODY = "initial body";
+
+  @Test
+  @DisplayName("Expect not empty Fragment body when Action configuration specifies body.")
+  void applyAction(VertxTestContext testContext) throws Throwable {
+    // given
+    Fragment fragment = new Fragment("type", new JsonObject(), INITIAL_BODY);
+    Action action = new InlineBodyActionFactory().create("action", new JsonObject().put("body",
+        EXPECTED_VALUE), null, null);
+
+    // when
+    action.apply(new FragmentContext(fragment, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(() -> {
+            Assertions.assertTrue(result.succeeded());
+            Assertions.assertEquals(EXPECTED_VALUE, result.result().getFragment().getBody());
+          });
+          testContext.completeNow();
+        });
+
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @Test
+  @DisplayName("Expect empty Fragment body when Action configuration does not specify body.")
+  void applyActionWithEmptyConfiguration(VertxTestContext testContext) throws Throwable {
+    // given
+    Fragment fragment = new Fragment("type", new JsonObject(), INITIAL_BODY);
+    Action action = new InlineBodyActionFactory().create("action", new JsonObject(), null, null);
+
+    // when
+    action.apply(new FragmentContext(fragment, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(() -> {
+            Assertions.assertTrue(result.succeeded());
+            Assertions.assertEquals("", result.result().getFragment().getBody());
+          });
+          testContext.completeNow();
+        });
+
+    Assertions.assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+}

--- a/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
+++ b/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.action;
 
 import io.knotx.fragment.Fragment;


### PR DESCRIPTION
Inline Body Action allows you to replace the Fragment body with a new value.

## Description
When Action responds with the `_error` transition we can apply some logic to handle this incorrect situation. It can be easily done with Inline Body Action that replace the Fragment body with a configured value.

## Motivation and Context
Fallback mechanism.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
