### PR TITLE
Inline Payload Action implementation

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -71,16 +71,39 @@ Read more about configuring fragment graph in the [Data Object docs](https://git
 ## Actions
 
 ### Inline Body Action
-Inline Body Action replaces Fragment body with specified value. Its configuration looks like:
+Inline Body Action replaces Fragment body with specified body. Its configuration looks like:
 ```hocon
 product-fallback {
-    factory = "inline-body"
-    config {
-      body = <div>Product not available at the moment</div>
-    }
+  factory = "inline-body"
+  config {
+    body = <div>Product not available at the moment</div>
+  }
 }
 ```
 
 The default `body` value is empty content.
+
+### Inline Payload Action
+Inline Payload Action puts JSON / JSON Array in Fragment payload with specified key (alias). Its 
+configuration looks like:
+```hocon
+product-fallback {
+  factory = "inline-payload"
+  config {
+    alias = product
+    payload {
+      product {
+        productId = 1234
+        description = "some description"
+      }
+    }
+    # payload = [
+    #   "first product", "second product"
+    # ]
+  }
+}
+```
+
+The default `alias` is action alias.
 
 ## Behaviours 

--- a/core/README.md
+++ b/core/README.md
@@ -92,10 +92,8 @@ product-fallback {
   config {
     alias = product
     payload {
-      product {
-        productId = 1234
-        description = "some description"
-      }
+      productId = 1234
+      description = "some description"
     }
     # payload = [
     #   "first product", "second product"

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlinePayloadActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlinePayloadActionFactory.java
@@ -1,0 +1,45 @@
+package io.knotx.fragments.handler.action;
+
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.ActionFactory;
+import io.knotx.fragments.handler.api.Cacheable;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+@Cacheable
+public class InlinePayloadActionFactory implements ActionFactory {
+
+  @Override
+  public String getName() {
+    return "inline-payload";
+  }
+
+  /**
+   * Creates Inline Payload Action that puts JsonObject / JsonArray to Fragment payload with alias
+   * key.
+   *
+   * @param alias - action alias
+   * @param config - JSON configuration
+   * @param vertx - vertx instance
+   * @param doAction - <pre>null</pre> value expected
+   */
+  @Override
+  public Action create(String alias, JsonObject config, Vertx vertx, Action doAction) {
+    if (doAction != null) {
+      throw new IllegalArgumentException("Inline Payload Action does not support doAction");
+    }
+    if (!config.containsKey("payload")) {
+      throw new IllegalArgumentException("Inline Payload Action requires payload parameter");
+    }
+    return (fragmentContext, resultHandler) -> {
+      String key = config.getString("alias", alias);
+      fragmentContext.getFragment().appendPayload(key, config.getMap().get("payload"));
+      Future<FragmentResult> resultFuture = Future.succeededFuture(
+          new FragmentResult(fragmentContext.getFragment(), FragmentResult.SUCCESS_TRANSITION));
+      resultFuture.setHandler(resultHandler);
+    };
+  }
+
+}

--- a/core/src/main/java/io/knotx/fragments/handler/action/InlinePayloadActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InlinePayloadActionFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.action;
 
 import io.knotx.fragments.handler.api.Action;

--- a/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
+++ b/core/src/test/java/io/knotx/fragments/handler/action/InlineBodyActionFactoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.knotx.fragments.handler.action;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import io.knotx.fragment.Fragment;
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
@@ -31,15 +33,26 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(VertxExtension.class)
 class InlineBodyActionFactoryTest {
 
+  private static final String ACTION_ALIAS = "action";
   private static final String EXPECTED_VALUE = "expected value";
   private static final String INITIAL_BODY = "initial body";
+
+  @Test
+  @DisplayName("Expect IllegalArgumentException when doAction specified.")
+  void createActionWithDoAction() {
+    // when, then
+    assertThrows(IllegalArgumentException.class, () -> new InlineBodyActionFactory()
+        .create(ACTION_ALIAS, new JsonObject(), null,
+            (fragmentContext, resultHandler) -> {
+            }));
+  }
 
   @Test
   @DisplayName("Expect not empty Fragment body when Action configuration specifies body.")
   void applyAction(VertxTestContext testContext) throws Throwable {
     // given
     Fragment fragment = new Fragment("type", new JsonObject(), INITIAL_BODY);
-    Action action = new InlineBodyActionFactory().create("action", new JsonObject().put("body",
+    Action action = new InlineBodyActionFactory().create(ACTION_ALIAS, new JsonObject().put("body",
         EXPECTED_VALUE), null, null);
 
     // when

--- a/core/src/test/java/io/knotx/fragments/handler/action/InlinePayloadActionFactoryTest.java
+++ b/core/src/test/java/io/knotx/fragments/handler/action/InlinePayloadActionFactoryTest.java
@@ -1,0 +1,143 @@
+package io.knotx.fragments.handler.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.knotx.fragment.Fragment;
+import io.knotx.fragments.handler.api.Action;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.server.api.context.ClientRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+class InlinePayloadActionFactoryTest {
+
+  private static final JsonArray EXPECTED_JSON_ARRAY = new JsonArray().add("some value");
+  private static final JsonObject EXPECTED_JSON_OBJECT = new JsonObject()
+      .put("data", "default value");
+  private static final String ACTION_ALIAS = "action";
+  private static final Fragment FRAGMENT = new Fragment("type", new JsonObject(), "body");
+
+  @Test
+  @DisplayName("Expect IllegalArgumentException when payload not configured.")
+  void createActionWithoutPayload() {
+    // when, then
+    assertThrows(IllegalArgumentException.class, () -> new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS, new JsonObject(), null, null));
+  }
+
+  @Test
+  @DisplayName("Expect IllegalArgumentException when doAction specified.")
+  void createActionWithDoAction() {
+    // when, then
+    assertThrows(IllegalArgumentException.class, () -> new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS, new JsonObject().put("payload", EXPECTED_JSON_OBJECT), null,
+            (fragmentContext, resultHandler) -> {
+            }));
+  }
+
+  @Test
+  @DisplayName("Expect payload with action alias key in Fragment payload when alias not configured.")
+  void applyActionWithActionAlias(VertxTestContext testContext) throws Throwable {
+    // given
+    Action action = new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS, new JsonObject().put("payload", EXPECTED_JSON_OBJECT), null, null);
+
+    // when
+    action.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(() -> assertTrue(
+              result.result().getFragment().getPayload().containsKey(ACTION_ALIAS)));
+          testContext.completeNow();
+        });
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @Test
+  @DisplayName("Expect payload with alias key in Fragment payload when alias configured")
+  void applyActionWithAlias(VertxTestContext testContext) throws Throwable {
+    // given
+    String expectedAlias = "newAction";
+    Action action = new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS,
+            new JsonObject().put("alias", expectedAlias).put("payload", EXPECTED_JSON_OBJECT), null,
+            null);
+
+    // when
+    action.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(
+              () -> assertTrue(
+                  result.result().getFragment().getPayload().containsKey(expectedAlias)));
+          testContext.completeNow();
+        });
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @Test
+  @DisplayName("Expect JSON in Fragment payload when JSON configured")
+  void applyActionWhenJSON(VertxTestContext testContext) throws Throwable {
+    // given
+    Action action = new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS,
+            new JsonObject().put("payload", EXPECTED_JSON_OBJECT), null, null);
+
+    // when
+    action.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(
+              () -> assertEquals(EXPECTED_JSON_OBJECT,
+                  result.result().getFragment().getPayload().getJsonObject(ACTION_ALIAS)));
+          testContext.completeNow();
+        });
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  @Test
+  @DisplayName("Expect JSON array in Fragment payload when JSON array configured")
+  void applyActionWhenArray(VertxTestContext testContext) throws Throwable {
+    // given
+    Action action = new InlinePayloadActionFactory()
+        .create(ACTION_ALIAS,
+            new JsonObject().put("payload", EXPECTED_JSON_ARRAY), null, null);
+
+    // when
+    action.apply(new FragmentContext(FRAGMENT, new ClientRequest()),
+        result -> {
+          // then
+          testContext.verify(
+              () -> assertEquals(EXPECTED_JSON_ARRAY,
+                  result.result().getFragment().getPayload().getJsonArray(ACTION_ALIAS)));
+          testContext.completeNow();
+        });
+
+    assertTrue(testContext.awaitCompletion(5, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+}

--- a/core/src/test/java/io/knotx/fragments/handler/action/InlinePayloadActionFactoryTest.java
+++ b/core/src/test/java/io/knotx/fragments/handler/action/InlinePayloadActionFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.fragments.handler.action;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Inline Payload Action.

## Description
Action allows to put JSON/JSON Array to Fragment payload. It can be used as Fallback solution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
