### PR TITLE
Adding request params to InMemoryCacheAction

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -142,8 +142,12 @@ product-cache {
       # in milliseconds
       ttl = 5000
     }
-    key = product
+    cacheKey = "product-{param.id}"
+    payloadKey = product
   }
   doAction = product-cb
 }
 ```
+Please note that cacheKey can be parametrized with request data like params, headers etc. Read 
+[Knot.x HTTP Server Common Placeholders](https://github.com/Knotx/knotx-server-http/tree/master/common/placeholders)
+documentation for more details. 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(project(":knotx-fragments-handler-api"))
     implementation(project(":knotx-fragments-engine"))
 
+    implementation(group = "io.knotx", name = "knotx-server-http-common-placeholders")
     implementation(group = "org.apache.commons", name = "commons-lang3")
     implementation(group = "com.google.guava", name = "guava")
     implementation(group = "io.vertx", name = "vertx-circuit-breaker")

--- a/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
@@ -108,7 +108,7 @@ public class InMemoryCacheActionFactory implements ActionFactory {
     String result = config.getString("payloadKey");
     if (StringUtils.isBlank(result)) {
       throw new IllegalArgumentException(
-          "Action requires doActionPayloadKey value in configuration.");
+          "Action requires payloadKey value in configuration.");
     }
     return result;
   }

--- a/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
@@ -25,7 +25,7 @@ import io.knotx.fragments.handler.api.Cacheable;
 import io.knotx.fragments.handler.api.domain.FragmentContext;
 import io.knotx.fragments.handler.api.domain.FragmentResult;
 import io.knotx.server.api.context.ClientRequest;
-import io.knotx.server.common.placeholders.UriTransformer;
+import io.knotx.server.common.placeholders.PlaceholdersResolver;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -118,7 +118,7 @@ public class InMemoryCacheActionFactory implements ActionFactory {
     if (StringUtils.isBlank(key)) {
       throw new IllegalArgumentException("Action requires cacheKey value in configuration.");
     }
-    return UriTransformer.resolveServicePath(key, clientRequest);
+    return PlaceholdersResolver.resolve(key, clientRequest);
   }
 
   private Cache<String, Object> createCache(JsonObject config) {

--- a/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
+++ b/core/src/main/java/io/knotx/fragments/handler/action/InMemoryCacheActionFactory.java
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.StringUtils;
  *         maximumSize = 1000
  *         ttl = 5000
  *       }
- *       cacheKey = product-{params.id}
+ *       cacheKey = product-{param.id}
  *       payloadKey = product
  *     }
  *   }


### PR DESCRIPTION
Cache key allows to be parametrized with request data like params, headers etc.

## Motivation and Context
We have one Product Detailed Page template that is used to generate all products pages. It uses request param that is then used in HTTP Action. The template contains many components that use HTTP Action so we want to cache the data per product. In-memory Cache Action must support similar placeholder functionality like HTTP Action:
```
cacheKey = product-{param.id}
```
or
```
cacheKey = product-{header.id}
```

## Upgrade notes (if appropriate)
New feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
