### PR TITLE
Error log entry added when parallel ends with error

### DIFF
--- a/engine/src/main/java/io/knotx/fragments/engine/TaskExecutionContext.java
+++ b/engine/src/main/java/io/knotx/fragments/engine/TaskExecutionContext.java
@@ -121,6 +121,9 @@ class TaskExecutionContext {
     String nextTransition = status.getDefaultTransition().orElse(null);
     if (status == Status.SUCCESS) {
       handleSuccess(nextTransition);
+    } else {
+      fragmentEvent
+          .log(EventLogEntry.error(taskName, currentNode.getId(), nextTransition));
     }
     return new FragmentResult(fragmentEvent.getFragment(), nextTransition);
   }

--- a/engine/src/test/java/io/knotx/fragments/engine/FragmentEventLogVerifier.java
+++ b/engine/src/test/java/io/knotx/fragments/engine/FragmentEventLogVerifier.java
@@ -28,7 +28,7 @@ class FragmentEventLogVerifier {
   private static final String ASSERTION_DIFFERENT_SIZE = "Log entries does not have the same size!\nExpected:\n%s,\ncurrent:\n%s";
 
 
-  static void verifyLogEntries(JsonObject log, Operation... expectedOperations) {
+  static void verifyAllLogEntries(JsonObject log, Operation... expectedOperations) {
     JsonArray logArray = log.getJsonArray("operations", new JsonArray());
     if (logArray.size() != expectedOperations.length) {
       throw new AssertionError(
@@ -41,6 +41,18 @@ class FragmentEventLogVerifier {
           .findAny()
           .orElseThrow(() -> new AssertionError(
                   String.format(ASSERTION_NOT_MATCH, Arrays.toString(expectedOperations), logArray)));
+    }
+  }
+
+  static void verifyLogEntries(JsonObject log, Operation... expectedOperations) {
+    JsonArray logArray = log.getJsonArray("operations", new JsonArray());
+    for (Operation expectedOperation : expectedOperations) {
+      Position position = expectedOperation.getPosition();
+      getSliceOfLog(logArray, position)
+          .filter(expectedOperation::matches)
+          .findAny()
+          .orElseThrow(() -> new AssertionError(
+              String.format(ASSERTION_NOT_MATCH, Arrays.toString(expectedOperations), logArray)));
     }
   }
 

--- a/engine/src/test/java/io/knotx/fragments/engine/TaskEngineScenariosTest.java
+++ b/engine/src/test/java/io/knotx/fragments/engine/TaskEngineScenariosTest.java
@@ -17,7 +17,7 @@
  */
 package io.knotx.fragments.engine;
 
-import static io.knotx.fragments.engine.FragmentEventLogVerifier.verifyLogEntries;
+import static io.knotx.fragments.engine.FragmentEventLogVerifier.verifyAllLogEntries;
 import static io.knotx.fragments.engine.graph.CompositeNode.COMPOSITE_NODE_ID;
 import static io.knotx.fragments.engine.helpers.TestFunction.appendBody;
 import static io.knotx.fragments.engine.helpers.TestFunction.appendBodyWithPayload;
@@ -191,7 +191,7 @@ class TaskEngineScenariosTest {
     verifyExecution(result, testContext,
         fragmentEvent -> {
           assertEquals(Status.SUCCESS, fragmentEvent.getStatus());
-          verifyLogEntries(fragmentEvent.getLogAsJson(),
+          verifyAllLogEntries(fragmentEvent.getLogAsJson(),
               Operation.exact("task", "first", "SUCCESS", 0),
               Operation.range("task", "A1", "SUCCESS", 1, 4),
               Operation.range("task", "A2", "ERROR", 1, 4),
@@ -308,7 +308,7 @@ class TaskEngineScenariosTest {
   private void verifyExecution(Single<FragmentEvent> result, VertxTestContext testContext,
       Consumer<FragmentEvent> successConsumer, int completionTimeout) throws Throwable {
     // execute
-    // verifyLogEntries
+    // verifyAllLogEntries
     result.subscribe(
         onSuccess -> testContext.verify(() -> {
           successConsumer.accept(onSuccess);

--- a/engine/src/test/java/io/knotx/fragments/engine/TaskEngineSingleOperationTest.java
+++ b/engine/src/test/java/io/knotx/fragments/engine/TaskEngineSingleOperationTest.java
@@ -17,7 +17,7 @@
  */
 package io.knotx.fragments.engine;
 
-import static io.knotx.fragments.engine.FragmentEventLogVerifier.verifyLogEntries;
+import static io.knotx.fragments.engine.FragmentEventLogVerifier.verifyAllLogEntries;
 import static io.knotx.fragments.engine.helpers.TestFunction.appendBody;
 import static io.knotx.fragments.engine.helpers.TestFunction.failure;
 import static io.knotx.fragments.engine.helpers.TestFunction.success;
@@ -209,7 +209,7 @@ class TaskEngineSingleOperationTest {
 
     // then
     verifyExecution(result, testContext,
-        event -> verifyLogEntries(event.getLogAsJson(),
+        event -> verifyAllLogEntries(event.getLogAsJson(),
             Operation.exact("task", "first", "SUCCESS", 0)
         ));
   }
@@ -227,7 +227,7 @@ class TaskEngineSingleOperationTest {
 
     // then
     verifyExecution(result, testContext,
-        event -> FragmentEventLogVerifier.verifyLogEntries(event.getLogAsJson(),
+        event -> FragmentEventLogVerifier.verifyAllLogEntries(event.getLogAsJson(),
             Operation.exact("task", "first", "ERROR", 0),
             Operation.exact("task", "first", "UNSUPPORTED_TRANSITION", 1)
         ));
@@ -248,7 +248,7 @@ class TaskEngineSingleOperationTest {
 
     // then
     verifyExecution(result, testContext,
-        event -> FragmentEventLogVerifier.verifyLogEntries(event.getLogAsJson(),
+        event -> FragmentEventLogVerifier.verifyAllLogEntries(event.getLogAsJson(),
             Operation.exact("task", "first", "SUCCESS", 0),
             Operation.exact("task", "first", "UNSUPPORTED_TRANSITION", 1)
         ));
@@ -268,7 +268,7 @@ class TaskEngineSingleOperationTest {
 
     // then
     verifyExecution(result, testContext,
-        event -> FragmentEventLogVerifier.verifyLogEntries(event.getLogAsJson(),
+        event -> FragmentEventLogVerifier.verifyAllLogEntries(event.getLogAsJson(),
             Operation.exact("task", "first", "ERROR", 0),
             Operation.exact("task", "second", "SUCCESS", 1)
         ));
@@ -277,7 +277,7 @@ class TaskEngineSingleOperationTest {
   private void verifyExecution(Single<FragmentEvent> result, VertxTestContext testContext,
       Consumer<FragmentEvent> successConsumer) throws Throwable {
     // execute
-    // verifyLogEntries
+    // verifyAllLogEntries
     result.subscribe(
         onSuccess -> testContext.verify(() -> {
           successConsumer.accept(onSuccess);


### PR DESCRIPTION
An error log entry is added when parallel ends with error.

## Motivation and Context
When parallel action ends with error transition that is handled, then there is no information in log that it failed.

### Incorrect situation
```
[Operation{task='task', name='first', status='SUCCESS'}, 
...
Operation{task='task', name='last', status='SUCCESS'}],
```

### Expected
```
[Operation{task='task', name='first', status='SUCCESS'}, 
... 
Operation{task='task', name='composite', status='ERROR'}, 
Operation{task='task', name='last', status='SUCCESS'}],
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
